### PR TITLE
ci: add AOT publish smoke test (item 1 of #15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,31 @@ jobs:
         with:
           name: test-results
           path: "**/*.trx"
+
+  aot-smoke:
+    runs-on: ubuntu-latest
+    # Publishes samples/ZeroAlloc.Results.AotSmoke with PublishAot=true and runs
+    # the binary. The library is pure runtime (no generator), so this job
+    # guards against any future reflection call sneaking into a Result/Maybe
+    # path — the ILC linker fires IL2026/IL3050 on such calls.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install AOT native toolchain
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Restore
+        run: dotnet restore samples/ZeroAlloc.Results.AotSmoke/ZeroAlloc.Results.AotSmoke.csproj
+
+      - name: Publish AOT
+        run: dotnet publish samples/ZeroAlloc.Results.AotSmoke/ZeroAlloc.Results.AotSmoke.csproj -r linux-x64 -c Release -o ./aot-out
+
+      - name: Run AOT binary
+        run: ./aot-out/ZeroAlloc.Results.AotSmoke

--- a/ZeroAlloc.Results.slnx
+++ b/ZeroAlloc.Results.slnx
@@ -2,6 +2,9 @@
   <Folder Name="/src/">
     <Project Path="src/ZeroAlloc.Results/ZeroAlloc.Results.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/ZeroAlloc.Results.AotSmoke/ZeroAlloc.Results.AotSmoke.csproj" />
+  </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/ZeroAlloc.Results.Tests/ZeroAlloc.Results.Tests.csproj" />
   </Folder>

--- a/samples/ZeroAlloc.Results.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Results.AotSmoke/Program.cs
@@ -1,0 +1,58 @@
+using System;
+using ZeroAlloc.Results;
+
+// Exercise every public Result / Maybe primitive the library ships under
+// PublishAot=true. Nothing here uses reflection, so if ILC complains or the
+// binary crashes it means we leaked a reflection call into the hot path —
+// this smoke test fails the build loudly.
+
+// 1. Result (non-generic)
+var ok = Result.Success();
+var err = Result.Failure("boom");
+if (!ok.IsSuccess) return Fail("Result.Success.IsSuccess should be true");
+if (!err.IsFailure) return Fail("Result.Failure.IsFailure should be true");
+if (!string.Equals(err.Error, "boom", StringComparison.Ordinal))
+    return Fail($"Result.Failure.Error expected 'boom', got '{err.Error}'");
+
+// 2. Result<T>
+var r1 = Result<int>.Success(42);
+var r1Err = Result<int>.Failure("no");
+if (r1.Value != 42) return Fail($"Result<int>.Value expected 42, got {r1.Value}");
+if (!r1Err.IsFailure) return Fail("Result<int>.Failure.IsFailure should be true");
+
+// 3. Result<T, E>
+var r2 = Result<int, string>.Success(7);
+var r2Err = Result<int, string>.Failure("nope");
+if (r2.Value != 7) return Fail($"Result<int,string>.Value expected 7, got {r2.Value}");
+if (!string.Equals(r2Err.Error, "nope", StringComparison.Ordinal))
+    return Fail($"Result<int,string>.Error expected 'nope', got '{r2Err.Error}'");
+
+// 4. UnitResult<E>
+var u = UnitResult<string>.Success();
+var uErr = UnitResult<string>.Failure("broken");
+if (!u.IsSuccess) return Fail("UnitResult<string>.Success.IsSuccess should be true");
+if (!string.Equals(uErr.Error, "broken", StringComparison.Ordinal))
+    return Fail($"UnitResult<string>.Error expected 'broken', got '{uErr.Error}'");
+
+// 5. Maybe<T>
+var some = Maybe<int>.Some(99);
+var none = Maybe<int>.None;
+if (!some.HasValue) return Fail("Maybe.Some.HasValue should be true");
+if (some.Value != 99) return Fail($"Maybe.Some.Value expected 99, got {some.Value}");
+if (!none.HasNoValue) return Fail("Maybe.None.HasNoValue should be true");
+if (none.GetValueOrDefault(-1) != -1)
+    return Fail("Maybe.None.GetValueOrDefault did not return fallback");
+
+// 6. Implicit conversion: any T → Maybe<T>.Some(T)
+Maybe<int> implicitSome = 123;
+if (!implicitSome.HasValue || implicitSome.Value != 123)
+    return Fail("Implicit T → Maybe<T> conversion broken");
+
+Console.WriteLine("AOT smoke: PASS");
+return 0;
+
+static int Fail(string message)
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — {message}");
+    return 1;
+}

--- a/samples/ZeroAlloc.Results.AotSmoke/ZeroAlloc.Results.AotSmoke.csproj
+++ b/samples/ZeroAlloc.Results.AotSmoke/ZeroAlloc.Results.AotSmoke.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Size</OptimizationPreference>
+
+    <!-- Per-call trim/AOT codes promoted to errors so a regression in the
+         runtime primitive (e.g. a new reflection call) fails the build loudly.
+         Assembly-level roll-ups (IL2104 / IL3053) stay warnings. -->
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2075;IL2091;IL3050;IL3051</WarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZeroAlloc.Results\ZeroAlloc.Results.csproj"
+                      SetTargetFramework="TargetFramework=net10.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
First checklist item of #15. Adds a sample that publishes with `PublishAot=true` and exercises every public type (Result, Result<T>, Result<T,E>, UnitResult<E>, Maybe<T>). CI job fails if the ILC linker raises per-call IL2026/IL3050 warnings or the binary exits non-zero.