### PR TITLE
perf: add BenchmarkDotNet project with Result vs throw/catch comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ obj/
 ## OS
 .DS_Store
 Thumbs.db
+
+# BenchmarkDotNet output
+BenchmarkDotNet.Artifacts/

--- a/ZeroAlloc.Results.slnx
+++ b/ZeroAlloc.Results.slnx
@@ -2,6 +2,9 @@
   <Folder Name="/src/">
     <Project Path="src/ZeroAlloc.Results/ZeroAlloc.Results.csproj" />
   </Folder>
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/ZeroAlloc.Results.Benchmarks/ZeroAlloc.Results.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/ZeroAlloc.Results.AotSmoke/ZeroAlloc.Results.AotSmoke.csproj" />
   </Folder>

--- a/benchmarks/ZeroAlloc.Results.Benchmarks/Program.cs
+++ b/benchmarks/ZeroAlloc.Results.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+public partial class Program { }

--- a/benchmarks/ZeroAlloc.Results.Benchmarks/ResultVsExceptionBenchmark.cs
+++ b/benchmarks/ZeroAlloc.Results.Benchmarks/ResultVsExceptionBenchmark.cs
@@ -1,0 +1,56 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using ZeroAlloc.Results;
+
+namespace ZeroAlloc.Results.Benchmarks;
+
+// Compares the allocation / throughput cost of propagating failure via
+// Result<T, E> (the zero-allocation path) against throwing-and-catching
+// exceptions (the baseline). Both variants are called in a tight loop so
+// the fixed per-iteration overhead dominates.
+//
+// The zero-allocation claim: Result<T, E> wraps value and error in a
+// readonly struct, so the failure path allocates 0 B/op.
+[MemoryDiagnoser]
+[SimpleJob]
+public class ResultVsExceptionBenchmark
+{
+    [Params(100)]
+    public int Iterations;
+
+    [Benchmark(Baseline = true, Description = "throw/catch")]
+    public int ThrowCatch()
+    {
+        var total = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            try { total += DivThrow(10, i % 3); }
+            catch (DivideByZeroException) { total += -1; }
+        }
+        return total;
+    }
+
+    [Benchmark(Description = "Result<int, string>")]
+    public int Result()
+    {
+        var total = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            var r = DivResult(10, i % 3);
+            total += r.IsSuccess ? r.Value : -1;
+        }
+        return total;
+    }
+
+    private static int DivThrow(int num, int denom)
+    {
+        if (denom == 0) throw new DivideByZeroException();
+        return num / denom;
+    }
+
+    private static Result<int, string> DivResult(int num, int denom)
+    {
+        if (denom == 0) return Result<int, string>.Failure("div by zero");
+        return Result<int, string>.Success(num / denom);
+    }
+}

--- a/benchmarks/ZeroAlloc.Results.Benchmarks/ZeroAlloc.Results.Benchmarks.csproj
+++ b/benchmarks/ZeroAlloc.Results.Benchmarks/ZeroAlloc.Results.Benchmarks.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Optimize>true</Optimize>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.4" />
+    <ProjectReference Include="..\..\src\ZeroAlloc.Results\ZeroAlloc.Results.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Adds a BenchmarkDotNet project with one representative benchmark: `Result<int, string>` failure path vs `throw/catch`. `MemoryDiagnoser` verifies 0 B/op on the Result path.

Follow-up: additional benchmarks for `Maybe<T>`, `Result.Bind/Map` chains, and `UnitResult<E>` can be added incrementally.