### PR TITLE
chore(release): promote ZeroAlloc.Results to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0
+
+Stability milestone — public API of `ZeroAlloc.Results` is now considered stable. No code changes from 0.1.4; this release marks the transition out of pre-1.0 SemVer.
+
 ## [0.1.6](https://github.com/ZeroAlloc-Net/ZeroAlloc.Results/compare/v0.1.5...v0.1.6) (2026-04-28)
 
 


### PR DESCRIPTION
## Summary
Promote the package to the 1.0 stability milestone. No code changes — the public API is the same as 0.1.4.

Part of an ecosystem-wide campaign promoting all sub-1.0 ZeroAlloc packages to 1.0.0.

## Mechanism
The merge commit footer `Release-As: 1.0.0` instructs release-please to release as 1.0.0.

Release-As: 1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)