### PR TITLE
feat: lock public API surface (PublicApiAnalyzers + api-compat gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,14 +106,19 @@ jobs:
         run: dotnet build src/ZeroAlloc.Results/ZeroAlloc.Results.csproj -c Release -p:Version=9999.0.0 -p:AssemblyVersion=9999.0.0.0 -p:FileVersion=9999.0.0.0
       - name: Pack current
         run: dotnet pack src/ZeroAlloc.Results/ZeroAlloc.Results.csproj -c Release --no-build --output ./current -p:Version=9999.0.0 -p:AssemblyVersion=9999.0.0.0 -p:FileVersion=9999.0.0.0
-      - name: Compare against latest published 1.x
+      - name: Compare against latest published version
+        # Take the highest released stable version overall (no major filter,
+        # exclude prerelease tags). Steady-state this gates each x.y.(z+1) patch
+        # against x.y.z and each x.(y+1).0 against x.y.(latest). Major bumps
+        # temporarily fire on intentional breaks, which is the correct cost.
         run: |
           latest=$(curl -s https://api.nuget.org/v3-flatcontainer/zeroalloc.results/index.json \
-                   | jq -r '.versions[]' | grep -E '^1\.' | tail -1)
+                   | jq -r '.versions[]' | grep -vE '(-|preview|alpha|beta|rc)' | tail -1)
           if [ -z "$latest" ]; then
-            echo "No published 1.x yet — skipping baseline check (Results is currently 0.1.x)."
+            echo "No stable releases on nuget.org yet — skipping baseline check."
             exit 0
           fi
+          echo "Comparing against published version: $latest"
           mkdir -p ./baseline
           curl -sL "https://api.nuget.org/v3-flatcontainer/zeroalloc.results/$latest/zeroalloc.results.$latest.nupkg" \
                -o ./baseline/baseline.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,30 @@ jobs:
 
       - name: Run AOT binary
         run: ./aot-out/ZeroAlloc.Results.AotSmoke
+
+  api-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+      - name: Install ApiCompat tool
+        run: dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
+      - name: Build current (sentinel assembly version >= any baseline so CP0003 never fires)
+        run: dotnet build src/ZeroAlloc.Results/ZeroAlloc.Results.csproj -c Release -p:Version=9999.0.0 -p:AssemblyVersion=9999.0.0.0 -p:FileVersion=9999.0.0.0
+      - name: Pack current
+        run: dotnet pack src/ZeroAlloc.Results/ZeroAlloc.Results.csproj -c Release --no-build --output ./current -p:Version=9999.0.0 -p:AssemblyVersion=9999.0.0.0 -p:FileVersion=9999.0.0.0
+      - name: Compare against latest published 1.x
+        run: |
+          latest=$(curl -s https://api.nuget.org/v3-flatcontainer/zeroalloc.results/index.json \
+                   | jq -r '.versions[]' | grep -E '^1\.' | tail -1)
+          if [ -z "$latest" ]; then
+            echo "No published 1.x yet — skipping baseline check (Results is currently 0.1.x)."
+            exit 0
+          fi
+          mkdir -p ./baseline
+          curl -sL "https://api.nuget.org/v3-flatcontainer/zeroalloc.results/$latest/zeroalloc.results.$latest.nupkg" \
+               -o ./baseline/baseline.nupkg
+          apicompat package ./current/*.nupkg --baseline-package ./baseline/baseline.nupkg

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,9 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
 
+    <!-- Lock public API surface: RS0016 = new public symbol not in PublicAPI.txt; RS0017 = declared symbol removed -->
+    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017</WarningsAsErrors>
+
     <!-- NuGet package metadata -->
     <Authors>Marcel Roozekrans</Authors>
     <Company>Marcel Roozekrans</Company>

--- a/src/ZeroAlloc.Results/PublicAPI.Shipped.txt
+++ b/src/ZeroAlloc.Results/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Results/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Results/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Results/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Results/PublicAPI.Unshipped.txt
@@ -1,1 +1,78 @@
 #nullable enable
+ZeroAlloc.Results.Extensions.ResultAsyncExtensions
+ZeroAlloc.Results.Extensions.ResultExtensions
+ZeroAlloc.Results.Extensions.ResultLinqExtensions
+ZeroAlloc.Results.IResult<T, E>
+ZeroAlloc.Results.IResult<T, E>.Error.get -> E
+ZeroAlloc.Results.IResult<T, E>.IsFailure.get -> bool
+ZeroAlloc.Results.IResult<T, E>.IsSuccess.get -> bool
+ZeroAlloc.Results.IResult<T, E>.Value.get -> T
+ZeroAlloc.Results.Maybe<T>
+ZeroAlloc.Results.Maybe<T>.GetValueOrDefault(T defaultValue = default(T)) -> T
+ZeroAlloc.Results.Maybe<T>.HasNoValue.get -> bool
+ZeroAlloc.Results.Maybe<T>.HasValue.get -> bool
+ZeroAlloc.Results.Maybe<T>.Maybe() -> void
+ZeroAlloc.Results.Maybe<T>.Value.get -> T
+ZeroAlloc.Results.Result
+ZeroAlloc.Results.Result.Error.get -> string!
+ZeroAlloc.Results.Result.IsFailure.get -> bool
+ZeroAlloc.Results.Result.IsSuccess.get -> bool
+ZeroAlloc.Results.Result.Result() -> void
+ZeroAlloc.Results.Result<T, E>
+ZeroAlloc.Results.Result<T, E>.Error.get -> E
+ZeroAlloc.Results.Result<T, E>.IsFailure.get -> bool
+ZeroAlloc.Results.Result<T, E>.IsSuccess.get -> bool
+ZeroAlloc.Results.Result<T, E>.Result() -> void
+ZeroAlloc.Results.Result<T, E>.Value.get -> T
+ZeroAlloc.Results.Result<T>
+ZeroAlloc.Results.Result<T>.Error.get -> string!
+ZeroAlloc.Results.Result<T>.IsFailure.get -> bool
+ZeroAlloc.Results.Result<T>.IsSuccess.get -> bool
+ZeroAlloc.Results.Result<T>.Result() -> void
+ZeroAlloc.Results.Result<T>.Value.get -> T
+ZeroAlloc.Results.UnitResult<E>
+ZeroAlloc.Results.UnitResult<E>.Error.get -> E
+ZeroAlloc.Results.UnitResult<E>.IsFailure.get -> bool
+ZeroAlloc.Results.UnitResult<E>.IsSuccess.get -> bool
+ZeroAlloc.Results.UnitResult<E>.UnitResult() -> void
+override ZeroAlloc.Results.Maybe<T>.ToString() -> string!
+override ZeroAlloc.Results.Result.ToString() -> string!
+override ZeroAlloc.Results.Result<T, E>.ToString() -> string!
+override ZeroAlloc.Results.Result<T>.ToString() -> string!
+override ZeroAlloc.Results.UnitResult<E>.ToString() -> string!
+static ZeroAlloc.Results.Extensions.ResultAsyncExtensions.Bind<T, U, E>(this System.Threading.Tasks.ValueTask<ZeroAlloc.Results.Result<T, E>> resultTask, System.Func<T, ZeroAlloc.Results.Result<U, E>>! bind) -> System.Threading.Tasks.ValueTask<ZeroAlloc.Results.Result<U, E>>
+static ZeroAlloc.Results.Extensions.ResultAsyncExtensions.BindAsync<T, U, E>(this ZeroAlloc.Results.Result<T, E> result, System.Func<T, System.Threading.Tasks.ValueTask<ZeroAlloc.Results.Result<U, E>>>! bind) -> System.Threading.Tasks.ValueTask<ZeroAlloc.Results.Result<U, E>>
+static ZeroAlloc.Results.Extensions.ResultAsyncExtensions.Map<T, U, E>(this System.Threading.Tasks.ValueTask<ZeroAlloc.Results.Result<T, E>> resultTask, System.Func<T, U>! map) -> System.Threading.Tasks.ValueTask<ZeroAlloc.Results.Result<U, E>>
+static ZeroAlloc.Results.Extensions.ResultAsyncExtensions.MapAsync<T, U, E>(this ZeroAlloc.Results.Result<T, E> result, System.Func<T, System.Threading.Tasks.ValueTask<U>>! map) -> System.Threading.Tasks.ValueTask<ZeroAlloc.Results.Result<U, E>>
+static ZeroAlloc.Results.Extensions.ResultAsyncExtensions.MatchAsync<T, E, U>(this ZeroAlloc.Results.Result<T, E> result, System.Func<T, System.Threading.Tasks.ValueTask<U>>! onSuccess, System.Func<E, System.Threading.Tasks.ValueTask<U>>! onFailure) -> System.Threading.Tasks.ValueTask<U>
+static ZeroAlloc.Results.Extensions.ResultAsyncExtensions.TapAsync<T, E>(this ZeroAlloc.Results.Result<T, E> result, System.Func<T, System.Threading.Tasks.ValueTask>! action) -> System.Threading.Tasks.ValueTask<ZeroAlloc.Results.Result<T, E>>
+static ZeroAlloc.Results.Extensions.ResultAsyncExtensions.TapErrorAsync<T, E>(this ZeroAlloc.Results.Result<T, E> result, System.Func<E, System.Threading.Tasks.ValueTask>! action) -> System.Threading.Tasks.ValueTask<ZeroAlloc.Results.Result<T, E>>
+static ZeroAlloc.Results.Extensions.ResultExtensions.Bind<T, U, E>(this ZeroAlloc.Results.Result<T, E> result, System.Func<T, ZeroAlloc.Results.Result<U, E>>! bind) -> ZeroAlloc.Results.Result<U, E>
+static ZeroAlloc.Results.Extensions.ResultExtensions.Bind<T, U>(this ZeroAlloc.Results.Result<T> result, System.Func<T, ZeroAlloc.Results.Result<U>>! bind) -> ZeroAlloc.Results.Result<U>
+static ZeroAlloc.Results.Extensions.ResultExtensions.Combine<T, E>(System.ReadOnlySpan<ZeroAlloc.Results.Result<T, E>> results) -> ZeroAlloc.Results.UnitResult<E>
+static ZeroAlloc.Results.Extensions.ResultExtensions.Ensure<T, E>(this ZeroAlloc.Results.Result<T, E> result, System.Func<T, bool>! predicate, E error) -> ZeroAlloc.Results.Result<T, E>
+static ZeroAlloc.Results.Extensions.ResultExtensions.Map<T, U, E>(this ZeroAlloc.Results.Result<T, E> result, System.Func<T, U>! map) -> ZeroAlloc.Results.Result<U, E>
+static ZeroAlloc.Results.Extensions.ResultExtensions.Map<T, U>(this ZeroAlloc.Results.Result<T> result, System.Func<T, U>! map) -> ZeroAlloc.Results.Result<U>
+static ZeroAlloc.Results.Extensions.ResultExtensions.MapError<T, E, F>(this ZeroAlloc.Results.Result<T, E> result, System.Func<E, F>! mapError) -> ZeroAlloc.Results.Result<T, F>
+static ZeroAlloc.Results.Extensions.ResultExtensions.Match<T, E, U>(this ZeroAlloc.Results.Result<T, E> result, System.Func<T, U>! onSuccess, System.Func<E, U>! onFailure) -> U
+static ZeroAlloc.Results.Extensions.ResultExtensions.Match<T, U>(this ZeroAlloc.Results.Result<T> result, System.Func<T, U>! onSuccess, System.Func<string!, U>! onFailure) -> U
+static ZeroAlloc.Results.Extensions.ResultExtensions.Tap<T, E>(this ZeroAlloc.Results.Result<T, E> result, System.Action<T>! action) -> ZeroAlloc.Results.Result<T, E>
+static ZeroAlloc.Results.Extensions.ResultExtensions.TapError<T, E>(this ZeroAlloc.Results.Result<T, E> result, System.Action<E>! action) -> ZeroAlloc.Results.Result<T, E>
+static ZeroAlloc.Results.Extensions.ResultLinqExtensions.Select<T, U, E>(this ZeroAlloc.Results.Result<T, E> result, System.Func<T, U>! selector) -> ZeroAlloc.Results.Result<U, E>
+static ZeroAlloc.Results.Extensions.ResultLinqExtensions.SelectMany<T, U, V, E>(this ZeroAlloc.Results.Result<T, E> result, System.Func<T, ZeroAlloc.Results.Result<U, E>>! bind, System.Func<T, U, V>! project) -> ZeroAlloc.Results.Result<V, E>
+static ZeroAlloc.Results.Maybe<T>.Some(T value) -> ZeroAlloc.Results.Maybe<T>
+static ZeroAlloc.Results.Maybe<T>.implicit operator ZeroAlloc.Results.Maybe<T>(T value) -> ZeroAlloc.Results.Maybe<T>
+static ZeroAlloc.Results.Result.Failure(string! error) -> ZeroAlloc.Results.Result
+static ZeroAlloc.Results.Result.Success() -> ZeroAlloc.Results.Result
+static ZeroAlloc.Results.Result<T, E>.Failure(E error) -> ZeroAlloc.Results.Result<T, E>
+static ZeroAlloc.Results.Result<T, E>.Success(T value) -> ZeroAlloc.Results.Result<T, E>
+static ZeroAlloc.Results.Result<T, E>.implicit operator ZeroAlloc.Results.Result<T, E>(E error) -> ZeroAlloc.Results.Result<T, E>
+static ZeroAlloc.Results.Result<T, E>.implicit operator ZeroAlloc.Results.Result<T, E>(T value) -> ZeroAlloc.Results.Result<T, E>
+static ZeroAlloc.Results.Result<T>.Failure(string! error) -> ZeroAlloc.Results.Result<T>
+static ZeroAlloc.Results.Result<T>.Success(T value) -> ZeroAlloc.Results.Result<T>
+static ZeroAlloc.Results.Result<T>.implicit operator ZeroAlloc.Results.Result<T>(T value) -> ZeroAlloc.Results.Result<T>
+static ZeroAlloc.Results.Result<T>.implicit operator ZeroAlloc.Results.Result<T>(string! error) -> ZeroAlloc.Results.Result<T>
+static ZeroAlloc.Results.UnitResult<E>.Failure(E error) -> ZeroAlloc.Results.UnitResult<E>
+static ZeroAlloc.Results.UnitResult<E>.Success() -> ZeroAlloc.Results.UnitResult<E>
+static ZeroAlloc.Results.UnitResult<E>.implicit operator ZeroAlloc.Results.UnitResult<E>(E error) -> ZeroAlloc.Results.UnitResult<E>
+static readonly ZeroAlloc.Results.Maybe<T>.None -> ZeroAlloc.Results.Maybe<T>

--- a/src/ZeroAlloc.Results/ZeroAlloc.Results.csproj
+++ b/src/ZeroAlloc.Results/ZeroAlloc.Results.csproj
@@ -8,4 +8,16 @@
     <Optimize>true</Optimize>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Adopts the public-API gating pattern from [ZeroAlloc.Authorization](https://github.com/ZeroAlloc-Net/ZeroAlloc.Authorization) for this repo. Phase A pilot of a family-wide rollout.

## What's added
- `Microsoft.CodeAnalysis.PublicApiAnalyzers` analyzer + `PublicAPI.Shipped.txt` (empty) / `PublicAPI.Unshipped.txt` (current public surface, 77 symbols)
- `RS0016` (new public symbol not declared) and `RS0017` (declared symbol removed) elevated to errors via `Directory.Build.props`
- `api-compat` CI job comparing current build against latest published 1.x baseline (currently 1.0.1)

## What this gates
- Adding a new public symbol without recording it in `PublicAPI.Unshipped.txt` -> compile error
- Removing or renaming a previously-declared symbol -> compile error
- Future binary-incompat changes between 1.x patches -> CI failure

## At next major release
Move the contents of `PublicAPI.Unshipped.txt` to `PublicAPI.Shipped.txt` so the surface is locked from that point.

## Note on current state
Results is already at 1.0.1, so the api-compat job will actively compare against the published 1.0.1 nupkg from day one (not a no-op). This catches any accidental binary-incompatible change immediately.

## Test plan
- [x] `dotnet build -c Release` clean (0 errors, 81 pre-existing analyzer warnings - same as baseline)
- [x] `dotnet test -c Release` passes (84/84 tests)
- [ ] CI all green: `lint-commits`, `build`, `aot-smoke`, `api-compat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)