### PR TITLE
ci: switch api-compat to reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,33 +93,7 @@ jobs:
         run: ./aot-out/ZeroAlloc.Results.AotSmoke
 
   api-compat:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.0.x
-      - name: Install ApiCompat tool
-        run: dotnet tool install --global Microsoft.DotNet.ApiCompat.Tool
-      - name: Build current (sentinel assembly version >= any baseline so CP0003 never fires)
-        run: dotnet build src/ZeroAlloc.Results/ZeroAlloc.Results.csproj -c Release -p:Version=9999.0.0 -p:AssemblyVersion=9999.0.0.0 -p:FileVersion=9999.0.0.0
-      - name: Pack current
-        run: dotnet pack src/ZeroAlloc.Results/ZeroAlloc.Results.csproj -c Release --no-build --output ./current -p:Version=9999.0.0 -p:AssemblyVersion=9999.0.0.0 -p:FileVersion=9999.0.0.0
-      - name: Compare against latest published version
-        # Take the highest released stable version overall (no major filter,
-        # exclude prerelease tags). Steady-state this gates each x.y.(z+1) patch
-        # against x.y.z and each x.(y+1).0 against x.y.(latest). Major bumps
-        # temporarily fire on intentional breaks, which is the correct cost.
-        run: |
-          latest=$(curl -s https://api.nuget.org/v3-flatcontainer/zeroalloc.results/index.json \
-                   | jq -r '.versions[]' | grep -vE '(-|preview|alpha|beta|rc)' | tail -1)
-          if [ -z "$latest" ]; then
-            echo "No stable releases on nuget.org yet — skipping baseline check."
-            exit 0
-          fi
-          echo "Comparing against published version: $latest"
-          mkdir -p ./baseline
-          curl -sL "https://api.nuget.org/v3-flatcontainer/zeroalloc.results/$latest/zeroalloc.results.$latest.nupkg" \
-               -o ./baseline/baseline.nupkg
-          apicompat package ./current/*.nupkg --baseline-package ./baseline/baseline.nupkg
+    uses: ZeroAlloc-Net/.github/.github/workflows/api-compat.yml@main
+    with:
+      package-id: ZeroAlloc.Results
+      csproj-path: src/ZeroAlloc.Results/ZeroAlloc.Results.csproj


### PR DESCRIPTION
## Summary
The reusable api-compat workflow at [ZeroAlloc-Net/.github](https://github.com/ZeroAlloc-Net/.github/blob/main/.github/workflows/api-compat.yml) (added in PR #10) lets every library consume the same gate in 4 lines. Replace this repo's ~22-line inline api-compat job with a `uses:` reference. Same migration as ZeroAlloc.Authorization#6.

## What changes
- `.github/workflows/ci.yml`: api-compat job becomes 4 lines instead of ~22.
- Behavior is identical — same comparison, same sentinel-version trick, same baseline source (latest stable on nuget.org).

## Test plan
- [ ] CI runs api-compat via the reusable workflow and passes (gates against `1.0.1` on nuget.org).

🤖 Generated with [Claude Code](https://claude.com/claude-code)