### PR TITLE
fix(release-please): drop pre-major flags (package is post-1.0)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Remove `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` from `release-please-config.json`.
- These flags are only meaningful for 0.x packages. ZeroAlloc.Results shipped 1.1.0, so the flags were a silent SemVer violation: `feat!` would have been demoted to a minor bump and `feat` to a patch.
- After this change release-please applies standard SemVer (major/minor/patch) bumps to a post-1.0 package.

## Test plan
- [ ] Confirm next release-please run produces the expected bump (e.g. a `feat:` commit -> minor; a `feat!:` / `BREAKING CHANGE` -> major) against current 1.1.0.
- [ ] Verify the open release-please PR (if any) refreshes with the corrected version.