### PR TITLE
fix(readme): absolute GitHub URLs so nuget.org links resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,18 +99,18 @@ Head-to-head vs [CSharpFunctionalExtensions](https://github.com/vkhorikov/CSharp
 | `Match` | 0.37 ns | 0.68 ns | **0 B** both | **1.9× faster** |
 | `Chain` (Map+Bind+Match) | 2.28 ns | 2.45 ns | **0 B** both | **1.1× faster** |
 
-See [docs/performance.md](docs/performance.md) for the full benchmark analysis and zero-allocation design explanation.
+See [docs/performance.md](https://github.com/ZeroAlloc-Net/ZeroAlloc.Results/blob/main/docs/performance.md) for the full benchmark analysis and zero-allocation design explanation.
 
 ## Documentation
 
 | Page | Description |
 |------|-------------|
-| [Getting Started](docs/getting-started.md) | Install and write your first result pipeline |
-| [Types](docs/types.md) | All five result types and when to use each |
-| [Combinators](docs/combinators.md) | Map, Bind, Match, Tap, Ensure, Combine |
-| [Async](docs/async.md) | ValueTask async variants for all combinators |
-| [LINQ](docs/linq.md) | Query syntax with Select and SelectMany |
-| [Performance](docs/performance.md) | Zero-alloc design and benchmark results |
+| [Getting Started](https://github.com/ZeroAlloc-Net/ZeroAlloc.Results/blob/main/docs/getting-started.md) | Install and write your first result pipeline |
+| [Types](https://github.com/ZeroAlloc-Net/ZeroAlloc.Results/blob/main/docs/types.md) | All five result types and when to use each |
+| [Combinators](https://github.com/ZeroAlloc-Net/ZeroAlloc.Results/blob/main/docs/combinators.md) | Map, Bind, Match, Tap, Ensure, Combine |
+| [Async](https://github.com/ZeroAlloc-Net/ZeroAlloc.Results/blob/main/docs/async.md) | ValueTask async variants for all combinators |
+| [LINQ](https://github.com/ZeroAlloc-Net/ZeroAlloc.Results/blob/main/docs/linq.md) | Query syntax with Select and SelectMany |
+| [Performance](https://github.com/ZeroAlloc-Net/ZeroAlloc.Results/blob/main/docs/performance.md) | Zero-alloc design and benchmark results |
 
 ## License
 


### PR DESCRIPTION
## Summary

Rewrite all relative links in `README.md` to absolute GitHub URLs. The README ships to nuget.org via `<PackageReadmeFile>`; nuget.org renders it in its own host context, so any `[text](docs/foo.md)` style links 404 on the package page today.

## Pattern

- File links: `[text](path)` -> `[text](https://github.com/ZeroAlloc-Net/<repo>/blob/main/path)`
- Directory links: `[text](path/)` -> `[text](https://github.com/ZeroAlloc-Net/<repo>/tree/main/path/)`
- Image links: `![alt](img.png)` -> `![alt](https://raw.githubusercontent.com/ZeroAlloc-Net/<repo>/main/img.png)` (raw host so the image renders inline)
- Anchors (`#section`) and already-absolute URLs (`https://...`) unchanged
- `#anchor` fragments preserved on rewritten file links

## Verification

`README.md` still renders cleanly on the GitHub repo page (absolute self-references work in GitHub's renderer too). Once merged, the next NuGet release publishes the updated README and nuget.org links will resolve to the actual files.

Generated with [Claude Code](https://claude.com/claude-code)
